### PR TITLE
Remove environment, requirements-document, and requirements-section services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ The application uses modern Go patterns and frameworks:
 ## Configuration
 
 ### Embedded Default Configuration
-The application includes pre-configured services embedded at compile-time for Catio microservices architecture. These can be found in `internal/config/default.yaml`. The embedded configuration includes 23 pre-configured services across different namespaces (catio-data-extraction, flyte) with various service types (rest, rpc, web, other).
+The application includes pre-configured services embedded at compile-time for Catio microservices architecture. These can be found in `internal/config/default.yaml`. The embedded configuration includes 20 pre-configured services across different namespaces (catio-data-extraction, flyte) with various service types (rest, rpc, web, other).
 
 ### User Configuration Override
 Users can create `~/.config/kportforward/config.yaml` to add services or override defaults:
@@ -231,7 +231,7 @@ uiOptions:
 - **Cross-Platform**: Works on macOS, Linux, and Windows
 - **Modern Terminal UI**: Interactive interface with real-time updates and keyboard navigation
 - **Automatic Recovery**: Monitors and restarts failed port-forwards with exponential backoff
-- **Embedded Configuration**: 23 pre-configured services with user override capability
+- **Embedded Configuration**: 20 pre-configured services with user override capability
 - **Auto-Updates**: Daily update checks with in-UI notifications
 
 ### Advanced Features

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -6,36 +6,12 @@ portForwards:
     localPort: 50100
     namespace: "catio-data-extraction"
     type: "rpc"
-  environment:
-    target: "service/environment"
-    targetPort: 80
-    localPort: 50800
-    namespace: "catio-data-extraction"
-    type: "rest"
-    swaggerPath: "configuration/swagger"
-    apiPath: "api/environment"
   initialization:
     target: "service/initialization"
     targetPort: 80
     localPort: 50801
     namespace: "catio-data-extraction"
     type: "rest"
-  requirements-document:
-    target: "service/requirements-document"
-    targetPort: 80
-    localPort: 50805
-    namespace: "catio-data-extraction"
-    type: "rest"
-    swaggerPath: "configuration/swagger"
-    apiPath: "api/requirements-document"
-  requirements-section:
-    target: "service/requirements-section"
-    targetPort: 80
-    localPort: 50806
-    namespace: "catio-data-extraction"
-    type: "rest"
-    swaggerPath: "configuration/swagger"
-    apiPath: "api/requirements-section"
   recommendations-mgnt:
     target: "service/recommendations-mgnt"
     targetPort: 50051


### PR DESCRIPTION
## Summary
- Remove `environment`, `requirements-document`, and `requirements-section` from embedded port-forward defaults
- Update service count in CLAUDE.md (23 → 20)

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)