### PR TITLE
Add akb-search-api to default config

### DIFF
--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -147,6 +147,13 @@ portForwards:
     namespace: "catio-data-extraction"
     type: "rpc"
 
+  akb-search-api:
+    target: "service/akb-search-api"
+    targetPort: 80
+    localPort: 50117
+    namespace: "catio-data-extraction"
+    type: "rpc"
+
 monitoringInterval: 1s
 uiOptions:
   refreshRate: 100ms


### PR DESCRIPTION
Adds akb-search-api gRPC service on local port 50117 (target service/akb-search-api:80 in catio-data-extraction).