### PR TITLE
Add architecture-knowledge-base-ui web port-forward

### DIFF
--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -154,6 +154,14 @@ portForwards:
     namespace: "catio-data-extraction"
     type: "rpc"
 
+  # Architecture Knowledge Base UI WEB
+  architecture-knowledge-base-ui:
+    target: "service/architecture-knowledge-base-ui"
+    targetPort: 3000
+    localPort: 50118
+    namespace: "catio-data-extraction"
+    type: "web"
+
 monitoringInterval: 1s
 uiOptions:
   refreshRate: 100ms


### PR DESCRIPTION
Adds the AKB admin UI (`architecture-knowledge-base-ui`, ClusterIP on port 3000 in `catio-data-extraction`) as a `type: "web"` port-forward on localPort 50118, following the convention of the other web-based dev tools (e.g. `eval-dashboard`).

Tried to push directly to `main` per request, but the branch is protected — opening this PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)