### PR TITLE
Remove requirements-service from default port-forward config

### DIFF
--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -85,14 +85,6 @@ portForwards:
     localPort: 50107
     namespace: "catio-data-extraction"
     type: "rpc"
-  # Requirements service
-  requirements-service:
-    target: "service/requirements-service"
-    targetPort: 80
-    localPort: 50109
-    namespace: "catio-data-extraction"
-    type: "rpc"
-
   # Question service
   question-service:
     target: "service/question-service"


### PR DESCRIPTION
Removes the `requirements-service` entry from the embedded default port-forward configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)