### PR TITLE
Add --multi-env: forward dev and prod at once on distinct ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ Invoke-WebRequest -Uri "https://github.com/catio-tech/kportforward/releases/late
    kportforward --grpcui --swaggerui --log-file /var/log/kportforward.log
    ```
 
+5. **Multiple environments at once** (`--multi-env`):
+   ```bash
+   # Forward dev AND prod simultaneously on distinct ports, each pinned to its
+   # own kubectl context — no manual context switching.
+   kportforward --multi-env
+   ```
+   - Without `--multi-env`, behavior is unchanged (single environment, current kubectl context).
+   - Environments come from a **separate** config, `environments.yaml` (embedded default; override at `~/.config/kportforward/environments.yaml`). Each environment pins a `context` and lists its own services/ports.
+   - Ports encode the environment: **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` is `50102` for dev, `70102` for prod).
+   - In `--multi-env` a port conflict is a **hard error** (no silent reassignment), so the local port always identifies the environment.
+
 ## ⚙️ Configuration
 
 kportforward uses embedded configuration for immediate functionality, with support for user customizations.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Invoke-WebRequest -Uri "https://github.com/catio-tech/kportforward/releases/late
    ```
    - Without `--multi-env`, behavior is unchanged (single environment, current kubectl context).
    - Environments come from a **separate** config, `environments.yaml` (embedded default; override at `~/.config/kportforward/environments.yaml`). Each environment pins a `context` and lists its own services/ports.
-   - Ports encode the environment: each service keeps the same last three digits and differs only by the prefix — **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` is `50102` for dev, `70102` for prod). (`overwatch` is dev-only and keeps `3030`.)
+   - Ports encode the environment: each service keeps the same last three digits and differs only by the prefix — **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` is `50102` for dev, `70102` for prod). (`overwatch` is dev-only, on `50030`.)
    - In `--multi-env` a port conflict is a **hard error** (no silent reassignment), so the local port always identifies the environment.
 
 ## ⚙️ Configuration

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Invoke-WebRequest -Uri "https://github.com/catio-tech/kportforward/releases/late
    ```
    - Without `--multi-env`, behavior is unchanged (single environment, current kubectl context).
    - Environments come from a **separate** config, `environments.yaml` (embedded default; override at `~/.config/kportforward/environments.yaml`). Each environment pins a `context` and lists its own services/ports.
-   - Ports encode the environment: **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` is `50102` for dev, `70102` for prod).
+   - Ports encode the environment: each service keeps the same last three digits and differs only by the prefix — **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` is `50102` for dev, `70102` for prod). (`overwatch` is dev-only and keeps `3030`.)
    - In `--multi-env` a port conflict is a **hard error** (no silent reassignment), so the local port always identifies the environment.
 
 ## ⚙️ Configuration

--- a/cmd/kportforward/main.go
+++ b/cmd/kportforward/main.go
@@ -32,6 +32,7 @@ var (
 	// CLI flags
 	enableGRPCUI         bool
 	enableSwaggerUI      bool
+	multiEnv             bool
 	logFile              string
 	configURL            string
 	pprofAddr            string
@@ -70,6 +71,7 @@ func main() {
 	// Add CLI flags
 	rootCmd.Flags().BoolVar(&enableGRPCUI, "grpcui", false, "Enable gRPC UI for RPC services")
 	rootCmd.Flags().BoolVar(&enableSwaggerUI, "swaggerui", false, "Enable Swagger UI for REST services")
+	rootCmd.Flags().BoolVar(&multiEnv, "multi-env", false, "Forward all environments at once (from environments.yaml) on distinct ports, each pinned to its kubectl context")
 	rootCmd.Flags().StringVar(&logFile, "log-file", "", "Write logs to file (default: logs are discarded to avoid interfering with TUI)")
 	rootCmd.Flags().StringVar(&configURL, "config-url", config.DefaultRemoteConfigURL, "URL to fetch default config from (set to \"\" to use embedded defaults only)")
 	rootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "Start pprof HTTP server (e.g. localhost:6060)")
@@ -114,10 +116,23 @@ func runPortForward(cmd *cobra.Command, args []string) {
 	// Set remote config URL (may be overridden by --config-url flag)
 	config.SetRemoteConfigURL(configURL)
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
+	// Load configuration. With --multi-env, load the separate environments config
+	// and flatten it into per-environment services pinned to their kubectl context;
+	// otherwise load the normal single-environment config (unchanged behavior).
+	var cfg *config.Config
+	var err error
+	if multiEnv {
+		var mec *config.MultiEnvConfig
+		mec, err = config.LoadMultiEnvConfig()
+		if err != nil {
+			log.Fatalf("Failed to load multi-env configuration: %v", err)
+		}
+		cfg = config.FlattenEnvironments(mec)
+	} else {
+		cfg, err = config.LoadConfig()
+		if err != nil {
+			log.Fatalf("Failed to load configuration: %v", err)
+		}
 	}
 
 	// Initialize logger
@@ -125,7 +140,11 @@ func runPortForward(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed to initialize logger: %v", err)
 	}
-	logger.Info("Starting kportforward with %d services", len(cfg.PortForwards))
+	if multiEnv {
+		logger.Info("Starting kportforward in multi-env mode with %d services", len(cfg.PortForwards))
+	} else {
+		logger.Info("Starting kportforward with %d services", len(cfg.PortForwards))
+	}
 
 	// Optional pprof server for live profiling
 	if pprofAddr != "" {
@@ -195,6 +214,7 @@ func runPortForward(cmd *cobra.Command, args []string) {
 
 	// Create port forward manager
 	manager := portforward.NewManager(cfg, logger)
+	manager.SetMultiEnv(multiEnv)
 
 	// Set UI handlers on the manager
 	manager.SetUIHandlers(grpcUIManager, swaggerUIManager)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -40,6 +41,74 @@ func LoadConfig() (*Config, error) {
 	// Merge user config into default config
 	mergedConfig := mergeConfigs(config, userConfig)
 	return mergedConfig, nil
+}
+
+// LoadMultiEnvConfig loads the multi-environment configuration used by --multi-env.
+// It starts from the embedded environments.yaml and, if the user has a
+// ~/.config/kportforward/environments.yaml, that file fully replaces the
+// embedded default (the environment list is explicit, not merged per-service).
+func LoadMultiEnvConfig() (*MultiEnvConfig, error) {
+	cfg := &MultiEnvConfig{}
+	if err := yaml.Unmarshal(DefaultEnvironmentsYAML, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse embedded environments config: %w", err)
+	}
+
+	if userPath, err := getUserMultiEnvConfigPath(); err == nil {
+		if data, err := os.ReadFile(userPath); err == nil {
+			userCfg := &MultiEnvConfig{}
+			if err := yaml.Unmarshal(data, userCfg); err != nil {
+				return nil, fmt.Errorf("failed to parse user environments config: %w", err)
+			}
+			cfg = userCfg
+		}
+	}
+
+	if len(cfg.Environments) == 0 {
+		return nil, fmt.Errorf("multi-env config has no environments")
+	}
+	// Fall back to the single-env defaults for unset UI/monitoring settings.
+	if cfg.MonitoringInterval == 0 {
+		cfg.MonitoringInterval = time.Second
+	}
+	if cfg.UIOptions.RefreshRate == 0 {
+		cfg.UIOptions.RefreshRate = 100 * time.Millisecond
+	}
+	if cfg.UIOptions.Theme == "" {
+		cfg.UIOptions.Theme = "dark"
+	}
+	return cfg, nil
+}
+
+// FlattenEnvironments collapses a MultiEnvConfig into a single Config whose
+// PortForwards contains every environment's services, each keyed as
+// "<service>-<env>" and pinned to that environment's kubectl context. This lets
+// the rest of the manager treat multi-env exactly like a large single-env run,
+// while every forward still targets the correct cluster.
+func FlattenEnvironments(mec *MultiEnvConfig) *Config {
+	out := &Config{
+		PortForwards:       make(map[string]Service),
+		MonitoringInterval: mec.MonitoringInterval,
+		UIOptions:          mec.UIOptions,
+	}
+	for _, env := range mec.Environments {
+		for name, service := range env.Services {
+			if service.Disabled {
+				continue
+			}
+			service.Context = env.Context
+			out.PortForwards[name+"-"+env.Name] = service
+		}
+	}
+	return out
+}
+
+// getUserMultiEnvConfigPath returns the user override path for the multi-env config.
+func getUserMultiEnvConfigPath() (string, error) {
+	base, err := getUserConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(base), "environments.yaml"), nil
 }
 
 // getUserConfigPath returns the appropriate config path for the current platform

--- a/internal/config/embedded.go
+++ b/internal/config/embedded.go
@@ -8,3 +8,8 @@ import (
 //
 //go:embed default.yaml
 var DefaultConfigYAML []byte
+
+// Embed the default multi-environment configuration file (used with --multi-env)
+//
+//go:embed environments.yaml
+var DefaultEnvironmentsYAML []byte

--- a/internal/config/environments.yaml
+++ b/internal/config/environments.yaml
@@ -1,0 +1,288 @@
+# Multi-environment configuration for kportforward.
+#
+# Used ONLY when the --multi-env flag is passed. Without --multi-env, kportforward
+# ignores this file and behaves exactly as before (single environment, current
+# kubectl context, ports from default.yaml / config.yaml).
+#
+# Each environment pins a kubectl context and forwards its own service list on a
+# distinct port band, so both run at once with no switchover and no ambiguity:
+#   dev  -> 50xxx (matches single-env ports)
+#   prod -> 70xxx  (prod port = 70000 + dev port % 1000)
+#
+# In --multi-env mode a port conflict is a hard error (no silent reassignment),
+# so the port always identifies the environment.
+#
+# User override: ~/.config/kportforward/environments.yaml (replaces this file).
+monitoringInterval: 1s
+uiOptions:
+  refreshRate: 100ms
+  theme: dark
+environments:
+- name: dev
+  context: arn:aws:eks:us-west-2:891377056770:cluster/catio-cluster
+  services:
+    arch-inventory:
+      target: service/architecture-inventory
+      targetPort: 80
+      localPort: 50100
+      namespace: catio-data-extraction
+      type: rpc
+    recommendations-mgnt:
+      target: service/recommendations-mgnt
+      targetPort: 50051
+      localPort: 50106
+      namespace: catio-data-extraction
+      type: rpc
+    process-monitor:
+      target: service/process-monitor-v2
+      targetPort: 5001
+      localPort: 50101
+      namespace: catio-data-extraction
+      type: rpc
+    extractor-config-service:
+      target: service/extractor-config-service-rpc
+      targetPort: 50051
+      localPort: 50102
+      namespace: catio-data-extraction
+      type: rpc
+    extractor-trigger:
+      target: service/extractor-trigger
+      targetPort: 80
+      localPort: 8027
+      namespace: catio-data-extraction
+      type: rest
+    workflow-trigger:
+      target: service/workflow-trigger
+      targetPort: 80
+      localPort: 50105
+      namespace: catio-data-extraction
+      type: rpc
+    file-management-api:
+      target: service/file-management-api
+      targetPort: 80
+      localPort: 50115
+      namespace: catio-data-extraction
+      type: rpc
+    flyte-console:
+      target: service/flyteconsole
+      targetPort: 80
+      localPort: 8088
+      namespace: flyte
+      type: web
+    flyte-admin-rpc:
+      target: service/flyteadmin
+      targetPort: 81
+      localPort: 8089
+      namespace: flyte
+      type: rpc
+      swaggerPath: configuration/swagger
+      apiPath: api
+    flyte-admin-web:
+      target: service/flyteadmin
+      targetPort: 80
+      localPort: 8081
+      namespace: flyte
+      type: other
+    archie-backend:
+      target: service/archie-backend
+      targetPort: 50051
+      localPort: 50108
+      namespace: catio-data-extraction
+      type: rpc
+    llm-router:
+      target: service/llm-router
+      targetPort: 80
+      localPort: 50107
+      namespace: catio-data-extraction
+      type: rpc
+    question-service:
+      target: service/question-service
+      targetPort: 80
+      localPort: 50110
+      namespace: catio-data-extraction
+      type: rpc
+    views-service:
+      target: service/views-service
+      targetPort: 50051
+      localPort: 50111
+      namespace: catio-data-extraction
+      type: rpc
+    catiopipe:
+      target: service/catiopipe-grpc
+      targetPort: 50051
+      localPort: 50112
+      namespace: catio-data-extraction
+      type: rpc
+    eval-service:
+      target: service/eval-service
+      targetPort: 50051
+      localPort: 50113
+      namespace: catio-data-extraction
+      type: rpc
+    eval-dashboard:
+      target: service/eval-dashboard
+      targetPort: 3000
+      localPort: 50114
+      namespace: catio-data-extraction
+      type: web
+    cost-api:
+      target: service/cost-api
+      targetPort: 50402
+      localPort: 50402
+      namespace: catio-data-extraction
+      type: rpc
+    workspace-management-api:
+      target: service/workspace-management-api
+      targetPort: 80
+      localPort: 50116
+      namespace: catio-data-extraction
+      type: rpc
+    akb-search-api:
+      target: service/akb-search-api
+      targetPort: 80
+      localPort: 50117
+      namespace: catio-data-extraction
+      type: rpc
+    architecture-knowledge-base-ui:
+      target: service/architecture-knowledge-base-ui
+      targetPort: 3000
+      localPort: 50118
+      namespace: catio-data-extraction
+      type: web
+    overwatch:
+      target: service/overwatch-web
+      targetPort: 80
+      localPort: 3030
+      namespace: overwatch-dev-us-a
+      type: web
+- name: prod
+  context: arn:aws:eks:us-west-2:090135924592:cluster/catio-cluster
+  services:
+    arch-inventory:
+      target: service/architecture-inventory
+      targetPort: 80
+      localPort: 70100
+      namespace: catio-data-extraction
+      type: rpc
+    recommendations-mgnt:
+      target: service/recommendations-mgnt
+      targetPort: 50051
+      localPort: 70106
+      namespace: catio-data-extraction
+      type: rpc
+    process-monitor:
+      target: service/process-monitor-v2
+      targetPort: 5001
+      localPort: 70101
+      namespace: catio-data-extraction
+      type: rpc
+    extractor-config-service:
+      target: service/extractor-config-service-rpc
+      targetPort: 50051
+      localPort: 70102
+      namespace: catio-data-extraction
+      type: rpc
+    extractor-trigger:
+      target: service/extractor-trigger
+      targetPort: 80
+      localPort: 70027
+      namespace: catio-data-extraction
+      type: rest
+    workflow-trigger:
+      target: service/workflow-trigger
+      targetPort: 80
+      localPort: 70105
+      namespace: catio-data-extraction
+      type: rpc
+    file-management-api:
+      target: service/file-management-api
+      targetPort: 80
+      localPort: 70115
+      namespace: catio-data-extraction
+      type: rpc
+    flyte-console:
+      target: service/flyteconsole
+      targetPort: 80
+      localPort: 70088
+      namespace: flyte
+      type: web
+    flyte-admin-rpc:
+      target: service/flyteadmin
+      targetPort: 81
+      localPort: 70089
+      namespace: flyte
+      type: rpc
+      swaggerPath: configuration/swagger
+      apiPath: api
+    flyte-admin-web:
+      target: service/flyteadmin
+      targetPort: 80
+      localPort: 70081
+      namespace: flyte
+      type: other
+    archie-backend:
+      target: service/archie-backend
+      targetPort: 50051
+      localPort: 70108
+      namespace: catio-data-extraction
+      type: rpc
+    llm-router:
+      target: service/llm-router
+      targetPort: 80
+      localPort: 70107
+      namespace: catio-data-extraction
+      type: rpc
+    question-service:
+      target: service/question-service
+      targetPort: 80
+      localPort: 70110
+      namespace: catio-data-extraction
+      type: rpc
+    views-service:
+      target: service/views-service
+      targetPort: 50051
+      localPort: 70111
+      namespace: catio-data-extraction
+      type: rpc
+    catiopipe:
+      target: service/catiopipe-grpc
+      targetPort: 50051
+      localPort: 70112
+      namespace: catio-data-extraction
+      type: rpc
+    eval-service:
+      target: service/eval-service
+      targetPort: 50051
+      localPort: 70113
+      namespace: catio-data-extraction
+      type: rpc
+    eval-dashboard:
+      target: service/eval-dashboard
+      targetPort: 3000
+      localPort: 70114
+      namespace: catio-data-extraction
+      type: web
+    cost-api:
+      target: service/cost-api
+      targetPort: 50402
+      localPort: 70402
+      namespace: catio-data-extraction
+      type: rpc
+    workspace-management-api:
+      target: service/workspace-management-api
+      targetPort: 80
+      localPort: 70116
+      namespace: catio-data-extraction
+      type: rpc
+    akb-search-api:
+      target: service/akb-search-api
+      targetPort: 80
+      localPort: 70117
+      namespace: catio-data-extraction
+      type: rpc
+    architecture-knowledge-base-ui:
+      target: service/architecture-knowledge-base-ui
+      targetPort: 3000
+      localPort: 70118
+      namespace: catio-data-extraction
+      type: web

--- a/internal/config/environments.yaml
+++ b/internal/config/environments.yaml
@@ -8,7 +8,7 @@
 # distinct port band, so both run at once with no switchover and no ambiguity.
 # For every service the last three digits (xxx) match across environments; only
 # the prefix differs:  dev -> 50xxx,  prod -> 70xxx  (prod = dev + 20000).
-# (overwatch is dev-only — its namespace is dev-specific — and keeps port 3030.)
+# (overwatch is dev-only — its namespace is dev-specific — so it has no prod entry.)
 #
 # In --multi-env mode a port conflict is a hard error (no silent reassignment),
 # so the port always identifies the environment.
@@ -153,7 +153,7 @@ environments:
     overwatch:
       target: service/overwatch-web
       targetPort: 80
-      localPort: 3030
+      localPort: 50030
       namespace: overwatch-dev-us-a
       type: web
 - name: prod

--- a/internal/config/environments.yaml
+++ b/internal/config/environments.yaml
@@ -5,9 +5,10 @@
 # kubectl context, ports from default.yaml / config.yaml).
 #
 # Each environment pins a kubectl context and forwards its own service list on a
-# distinct port band, so both run at once with no switchover and no ambiguity:
-#   dev  -> 50xxx (matches single-env ports)
-#   prod -> 70xxx  (prod port = 70000 + dev port % 1000)
+# distinct port band, so both run at once with no switchover and no ambiguity.
+# For every service the last three digits (xxx) match across environments; only
+# the prefix differs:  dev -> 50xxx,  prod -> 70xxx  (prod = dev + 20000).
+# (overwatch is dev-only — its namespace is dev-specific — and keeps port 3030.)
 #
 # In --multi-env mode a port conflict is a hard error (no silent reassignment),
 # so the port always identifies the environment.
@@ -48,7 +49,7 @@ environments:
     extractor-trigger:
       target: service/extractor-trigger
       targetPort: 80
-      localPort: 8027
+      localPort: 50027
       namespace: catio-data-extraction
       type: rest
     workflow-trigger:
@@ -66,13 +67,13 @@ environments:
     flyte-console:
       target: service/flyteconsole
       targetPort: 80
-      localPort: 8088
+      localPort: 50088
       namespace: flyte
       type: web
     flyte-admin-rpc:
       target: service/flyteadmin
       targetPort: 81
-      localPort: 8089
+      localPort: 50089
       namespace: flyte
       type: rpc
       swaggerPath: configuration/swagger
@@ -80,7 +81,7 @@ environments:
     flyte-admin-web:
       target: service/flyteadmin
       targetPort: 80
-      localPort: 8081
+      localPort: 50081
       namespace: flyte
       type: other
     archie-backend:

--- a/internal/config/environments_test.go
+++ b/internal/config/environments_test.go
@@ -51,6 +51,37 @@ func TestLoadMultiEnvConfigEmbedded(t *testing.T) {
 	}
 }
 
+// TestMultiEnvPortsMatchAcrossEnvironments verifies the embedded config's port
+// convention: every service present in both dev and prod shares the same last
+// three digits and differs only by the 50xxx (dev) / 70xxx (prod) prefix.
+func TestMultiEnvPortsMatchAcrossEnvironments(t *testing.T) {
+	mec, err := LoadMultiEnvConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiEnvConfig failed: %v", err)
+	}
+	byName := map[string]Environment{}
+	for _, e := range mec.Environments {
+		byName[e.Name] = e
+	}
+	dev, prod := byName["dev"], byName["prod"]
+
+	for name, ds := range dev.Services {
+		ps, ok := prod.Services[name]
+		if !ok {
+			continue // dev-only service (e.g. overwatch) — no prod counterpart
+		}
+		if ds.LocalPort/1000 != 50 {
+			t.Errorf("dev %s port %d is not in the 50xxx band", name, ds.LocalPort)
+		}
+		if ps.LocalPort/1000 != 70 {
+			t.Errorf("prod %s port %d is not in the 70xxx band", name, ps.LocalPort)
+		}
+		if ds.LocalPort%1000 != ps.LocalPort%1000 {
+			t.Errorf("%s: dev(%d) and prod(%d) must share the last three digits", name, ds.LocalPort, ps.LocalPort)
+		}
+	}
+}
+
 // TestFlattenEnvironments verifies services are env-qualified, context-pinned,
 // and keep their per-environment ports.
 func TestFlattenEnvironments(t *testing.T) {

--- a/internal/config/environments_test.go
+++ b/internal/config/environments_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLoadMultiEnvConfigEmbedded verifies the embedded environments.yaml parses
+// and contains a dev (50xxx) and prod (70xxx) environment, each pinned to a
+// distinct kubectl context.
+func TestLoadMultiEnvConfigEmbedded(t *testing.T) {
+	mec, err := LoadMultiEnvConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiEnvConfig failed: %v", err)
+	}
+	if len(mec.Environments) < 2 {
+		t.Fatalf("expected at least dev+prod environments, got %d", len(mec.Environments))
+	}
+
+	byName := map[string]Environment{}
+	for _, e := range mec.Environments {
+		if e.Context == "" {
+			t.Fatalf("environment %q has no context", e.Name)
+		}
+		if len(e.Services) == 0 {
+			t.Fatalf("environment %q has no services", e.Name)
+		}
+		byName[e.Name] = e
+	}
+
+	dev, ok := byName["dev"]
+	if !ok {
+		t.Fatal("missing dev environment")
+	}
+	prod, ok := byName["prod"]
+	if !ok {
+		t.Fatal("missing prod environment")
+	}
+	if dev.Context == prod.Context {
+		t.Fatalf("dev and prod must pin different contexts, both = %q", dev.Context)
+	}
+
+	// A representative service should sit in the 50xxx band for dev and 70xxx for prod.
+	ds, ok := dev.Services["extractor-config-service"]
+	if !ok || ds.LocalPort < 50000 || ds.LocalPort >= 60000 {
+		t.Fatalf("dev extractor-config-service expected in 50xxx, got %+v (ok=%v)", ds.LocalPort, ok)
+	}
+	ps, ok := prod.Services["extractor-config-service"]
+	if !ok || ps.LocalPort < 70000 || ps.LocalPort >= 80000 {
+		t.Fatalf("prod extractor-config-service expected in 70xxx, got %+v (ok=%v)", ps.LocalPort, ok)
+	}
+}
+
+// TestFlattenEnvironments verifies services are env-qualified, context-pinned,
+// and keep their per-environment ports.
+func TestFlattenEnvironments(t *testing.T) {
+	mec := &MultiEnvConfig{
+		Environments: []Environment{
+			{
+				Name:    "dev",
+				Context: "ctx-dev",
+				Services: map[string]Service{
+					"svc-a": {Target: "service/a", TargetPort: 80, LocalPort: 50100, Namespace: "ns"},
+					"svc-x": {Target: "service/x", TargetPort: 80, LocalPort: 50200, Namespace: "ns", Disabled: true},
+				},
+			},
+			{
+				Name:    "prod",
+				Context: "ctx-prod",
+				Services: map[string]Service{
+					"svc-a": {Target: "service/a", TargetPort: 80, LocalPort: 70100, Namespace: "ns"},
+				},
+			},
+		},
+	}
+
+	flat := FlattenEnvironments(mec)
+
+	if _, ok := flat.PortForwards["svc-x-dev"]; ok {
+		t.Fatal("disabled service should be omitted from flattened config")
+	}
+
+	dev, ok := flat.PortForwards["svc-a-dev"]
+	if !ok {
+		t.Fatal("missing svc-a-dev in flattened config")
+	}
+	if dev.Context != "ctx-dev" || dev.LocalPort != 50100 {
+		t.Fatalf("svc-a-dev wrong pinning: %+v", dev)
+	}
+
+	prod, ok := flat.PortForwards["svc-a-prod"]
+	if !ok {
+		t.Fatal("missing svc-a-prod in flattened config")
+	}
+	if prod.Context != "ctx-prod" || prod.LocalPort != 70100 {
+		t.Fatalf("svc-a-prod wrong pinning: %+v", prod)
+	}
+
+	// Same logical service, distinct keys/ports/contexts — the whole point.
+	if strings.HasPrefix(dev.Context, prod.Context) || dev.LocalPort == prod.LocalPort {
+		t.Fatal("dev and prod instances of svc-a must differ in context and port")
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -21,6 +21,27 @@ type Service struct {
 	SwaggerPath string `yaml:"swaggerPath,omitempty"`
 	APIPath     string `yaml:"apiPath,omitempty"`
 	Disabled    bool   `yaml:"disabled,omitempty"`
+	// Context pins this forward to a specific kubectl context (used by multi-env
+	// mode). Empty means "use the current kubectl context" — the default,
+	// single-environment behavior.
+	Context string `yaml:"context,omitempty"`
+}
+
+// MultiEnvConfig is the configuration used in --multi-env mode. It is loaded
+// from a separate file (environments.yaml) and is not related to the
+// single-environment Config above.
+type MultiEnvConfig struct {
+	Environments       []Environment `yaml:"environments"`
+	MonitoringInterval time.Duration `yaml:"monitoringInterval"`
+	UIOptions          UIConfig      `yaml:"uiOptions"`
+}
+
+// Environment is one entry in the multi-env config: a named environment pinned
+// to a kubectl context, with its own set of services (and their own ports).
+type Environment struct {
+	Name     string             `yaml:"name"`
+	Context  string             `yaml:"context"`
+	Services map[string]Service `yaml:"services"`
 }
 
 // UIConfig represents UI-specific configuration options

--- a/internal/portforward/manager.go
+++ b/internal/portforward/manager.go
@@ -38,6 +38,11 @@ type Manager struct {
 	kubernetesContext string
 	shuttingDown      bool
 
+	// multiEnv indicates each service is pinned to its own kubectl context
+	// (via Service.Context). In this mode ambient context changes must NOT
+	// restart services, and port conflicts fail loudly instead of reassigning.
+	multiEnv bool
+
 	// UI Handlers
 	grpcUIHandler    UIHandler
 	swaggerUIHandler UIHandler
@@ -98,6 +103,15 @@ func NewManager(cfg *config.Config, logger *utils.Logger) *Manager {
 	}
 }
 
+// SetMultiEnv enables multi-environment mode. Must be called before Start().
+// In multi-env mode services are pinned to per-service kubectl contexts, ambient
+// context changes do not trigger restarts, and port conflicts are fatal.
+func (m *Manager) SetMultiEnv(enabled bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.multiEnv = enabled
+}
+
 // SetUIHandlers sets the UI handlers for the manager
 func (m *Manager) SetUIHandlers(grpcUI, swaggerUI UIHandler) {
 	m.mutex.Lock()
@@ -132,6 +146,7 @@ func (m *Manager) Start() error {
 	// Create service managers
 	for name, serviceConfig := range m.config.PortForwards {
 		sm := NewServiceManager(name, serviceConfig, m.logger)
+		sm.strictPort = m.multiEnv
 		m.services[name] = sm
 	}
 
@@ -414,6 +429,7 @@ func (m *Manager) checkKubernetesContext() {
 
 	m.mutex.RLock()
 	currentContext := m.kubernetesContext
+	multiEnv := m.multiEnv
 	m.mutex.RUnlock()
 
 	// Log context check for debugging purposes
@@ -427,7 +443,9 @@ func (m *Manager) checkKubernetesContext() {
 		// Channel is full, skip this update
 	}
 
-	if newContext != currentContext && newContext != "N/A" {
+	// In multi-env mode each forward is pinned to its own context via --context,
+	// so a change to the ambient current-context must not tear everything down.
+	if newContext != currentContext && newContext != "N/A" && !multiEnv {
 		m.logger.Info("Kubernetes context changed from %s to %s, restarting all services",
 			currentContext, newContext)
 

--- a/internal/portforward/service.go
+++ b/internal/portforward/service.go
@@ -37,6 +37,10 @@ type ServiceManager struct {
 	lastHealthCheckTime time.Time
 	// Restart deduplication
 	restarting atomic.Bool
+	// strictPort disables automatic port reassignment (multi-env mode): on a
+	// port conflict the service fails loudly instead of silently moving ports,
+	// so the local port always identifies the environment.
+	strictPort bool
 }
 
 // NewServiceManager creates a new service manager
@@ -99,6 +103,7 @@ func (sm *ServiceManager) Start() error {
 		sm.config.Target,
 		actualPort,
 		sm.config.TargetPort,
+		sm.config.Context,
 		sm.logger,
 		sm.name,
 	)
@@ -401,6 +406,15 @@ func (sm *ServiceManager) Shutdown() {
 func (sm *ServiceManager) resolvePort() (int, error) {
 	if utils.IsPortAvailable(sm.config.LocalPort) {
 		return sm.config.LocalPort, nil
+	}
+
+	// Multi-env mode: never silently reassign — the port encodes the environment.
+	// Fail loudly so the conflict is visible instead of moving to a random port.
+	if sm.strictPort {
+		sm.logger.Error("Port %d for %s is already in use; refusing to reassign in --multi-env mode (free the port or fix the config)",
+			sm.config.LocalPort, sm.name)
+		return 0, fmt.Errorf("port %d for %s is already in use (multi-env: not reassigning)",
+			sm.config.LocalPort, sm.name)
 	}
 
 	// Port is in use, find an alternative

--- a/internal/portforward/service_strictport_test.go
+++ b/internal/portforward/service_strictport_test.go
@@ -1,0 +1,43 @@
+package portforward
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/victorkazakov/kportforward/internal/config"
+	"github.com/victorkazakov/kportforward/internal/utils"
+)
+
+// TestResolvePortStrictFailsOnConflict verifies that in multi-env (strict) mode a
+// port conflict is a hard error (no silent reassignment), while the default mode
+// still reassigns to a free port.
+func TestResolvePortStrictFailsOnConflict(t *testing.T) {
+	// Occupy a port so it is unavailable.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy a port: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	logger := utils.NewLoggerWithOutput(utils.LevelInfo, io.Discard)
+	svc := config.Service{Target: "service/x", TargetPort: 80, LocalPort: port, Namespace: "ns"}
+
+	// strict (multi-env): must fail loudly instead of reassigning.
+	smStrict := NewServiceManager("x-prod", svc, logger)
+	smStrict.strictPort = true
+	if _, err := smStrict.resolvePort(); err == nil {
+		t.Fatal("expected strict resolvePort to fail on a port conflict, got nil")
+	}
+
+	// default (single-env): must reassign to a different, free port.
+	smLoose := NewServiceManager("x", svc, logger)
+	got, err := smLoose.resolvePort()
+	if err != nil {
+		t.Fatalf("non-strict resolvePort should reassign, got error: %v", err)
+	}
+	if got == port {
+		t.Fatalf("non-strict resolvePort should have moved off the busy port %d", port)
+	}
+}

--- a/internal/utils/kubectl.go
+++ b/internal/utils/kubectl.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// BuildKubectlPortForwardArgs builds the argument list for `kubectl port-forward`.
+// When kubeContext is non-empty the forward is pinned to that context via
+// `--context`; otherwise the current kubectl context is used. Shared across
+// platforms so the (safety-critical) context pinning has a single definition.
+func BuildKubectlPortForwardArgs(namespace, target string, localPort, targetPort int, timeout time.Duration, kubeContext string) []string {
+	var args []string
+	if kubeContext != "" {
+		args = append(args, "--context", kubeContext)
+	}
+	args = append(args,
+		"port-forward",
+		"-n", namespace,
+		target,
+		fmt.Sprintf("%d:%d", localPort, targetPort),
+		"--request-timeout="+fmt.Sprintf("%.0fs", timeout.Seconds()),
+	)
+	return args
+}

--- a/internal/utils/kubectl_test.go
+++ b/internal/utils/kubectl_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildKubectlPortForwardArgs_NoContext(t *testing.T) {
+	args := BuildKubectlPortForwardArgs("catio-data-extraction", "service/extractor-config-service-rpc", 50102, 50051, 30*time.Second, "")
+
+	if args[0] != "port-forward" {
+		t.Fatalf("expected first arg to be port-forward, got %q (%v)", args[0], args)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--context") {
+		t.Fatalf("expected no --context when kubeContext is empty, got %v", args)
+	}
+	if !strings.Contains(joined, "50102:50051") {
+		t.Fatalf("expected port mapping 50102:50051 in %v", args)
+	}
+	if !strings.Contains(joined, "-n catio-data-extraction") {
+		t.Fatalf("expected namespace flag in %v", args)
+	}
+}
+
+func TestBuildKubectlPortForwardArgs_WithContext(t *testing.T) {
+	ctx := "arn:aws:eks:us-west-2:090135924592:cluster/catio-cluster"
+	args := BuildKubectlPortForwardArgs("catio-data-extraction", "service/extractor-config-service-rpc", 70102, 50051, 30*time.Second, ctx)
+
+	// --context must come before the port-forward subcommand.
+	if args[0] != "--context" || args[1] != ctx {
+		t.Fatalf("expected args to start with --context %q, got %v", ctx, args)
+	}
+	if args[2] != "port-forward" {
+		t.Fatalf("expected port-forward after context, got %v", args)
+	}
+	if !strings.Contains(strings.Join(args, " "), "70102:50051") {
+		t.Fatalf("expected port mapping 70102:50051 in %v", args)
+	}
+}

--- a/internal/utils/processes_unix.go
+++ b/internal/utils/processes_unix.go
@@ -14,19 +14,15 @@ import (
 )
 
 // StartKubectlPortForward starts a kubectl port-forward process with Unix-specific settings
-func StartKubectlPortForward(namespace, target string, localPort, targetPort int, logger *Logger, serviceName string) (*exec.Cmd, error) {
-	return StartKubectlPortForwardWithTimeout(namespace, target, localPort, targetPort, 30*time.Second, logger, serviceName)
+func StartKubectlPortForward(namespace, target string, localPort, targetPort int, kubeContext string, logger *Logger, serviceName string) (*exec.Cmd, error) {
+	return StartKubectlPortForwardWithTimeout(namespace, target, localPort, targetPort, 30*time.Second, kubeContext, logger, serviceName)
 }
 
-// StartKubectlPortForwardWithTimeout starts a kubectl port-forward process with a timeout
-func StartKubectlPortForwardWithTimeout(namespace, target string, localPort, targetPort int, timeout time.Duration, logger *Logger, serviceName string) (*exec.Cmd, error) {
-	args := []string{
-		"port-forward",
-		"-n", namespace,
-		target,
-		fmt.Sprintf("%d:%d", localPort, targetPort),
-		"--request-timeout=" + fmt.Sprintf("%.0fs", timeout.Seconds()),
-	}
+// StartKubectlPortForwardWithTimeout starts a kubectl port-forward process with a timeout.
+// When kubeContext is non-empty, the forward is pinned to that kubectl context
+// (--context); otherwise the current context is used.
+func StartKubectlPortForwardWithTimeout(namespace, target string, localPort, targetPort int, timeout time.Duration, kubeContext string, logger *Logger, serviceName string) (*exec.Cmd, error) {
+	args := BuildKubectlPortForwardArgs(namespace, target, localPort, targetPort, timeout, kubeContext)
 
 	cmd := exec.Command("kubectl", args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/internal/utils/processes_windows.go
+++ b/internal/utils/processes_windows.go
@@ -21,19 +21,15 @@ type ProcessInfo struct {
 }
 
 // StartKubectlPortForward starts a kubectl port-forward process with Windows-specific settings
-func StartKubectlPortForward(namespace, target string, localPort, targetPort int, logger *Logger, serviceName string) (*exec.Cmd, error) {
-	return StartKubectlPortForwardWithTimeout(namespace, target, localPort, targetPort, 30*time.Second, logger, serviceName)
+func StartKubectlPortForward(namespace, target string, localPort, targetPort int, kubeContext string, logger *Logger, serviceName string) (*exec.Cmd, error) {
+	return StartKubectlPortForwardWithTimeout(namespace, target, localPort, targetPort, 30*time.Second, kubeContext, logger, serviceName)
 }
 
-// StartKubectlPortForwardWithTimeout starts a kubectl port-forward process with a timeout on Windows
-func StartKubectlPortForwardWithTimeout(namespace, target string, localPort, targetPort int, timeout time.Duration, logger *Logger, serviceName string) (*exec.Cmd, error) {
-	args := []string{
-		"port-forward",
-		"-n", namespace,
-		target,
-		fmt.Sprintf("%d:%d", localPort, targetPort),
-		"--request-timeout=" + fmt.Sprintf("%.0fs", timeout.Seconds()),
-	}
+// StartKubectlPortForwardWithTimeout starts a kubectl port-forward process with a timeout on Windows.
+// When kubeContext is non-empty, the forward is pinned to that kubectl context
+// (--context); otherwise the current context is used.
+func StartKubectlPortForwardWithTimeout(namespace, target string, localPort, targetPort int, timeout time.Duration, kubeContext string, logger *Logger, serviceName string) (*exec.Cmd, error) {
+	args := BuildKubectlPortForwardArgs(namespace, target, localPort, targetPort, timeout, kubeContext)
 
 	cmd := exec.Command("kubectl", args...)
 


### PR DESCRIPTION
## Why

Today kportforward forwards services from the **ambient** kubectl context on fixed ports, so a port like `:50102` is environment-ambiguous — you switch context manually and the same port silently changes which cluster it hits. (This exact ambiguity recently caused a chain of confusion during a prod operation: a "dev" check was unknowingly hitting prod.)

## What

`--multi-env` forwards **every configured environment at once**, each pinned to its own kubectl context (`kubectl --context`), on a distinct port band. **Without the flag, behavior is exactly as before** (single environment, current context, automatic port reassignment).

- Ports encode the environment: **dev → `50xxx`**, **prod → `70xxx`** (e.g. `extractor-config-service` = `50102` dev / `70102` prod).
- In `--multi-env`, a port conflict is a **hard, loud error** (no silent reassignment) — the local port always identifies the environment.

## How

- **New, separate config** `environments.yaml` (embedded default; user override at `~/.config/kportforward/environments.yaml`) — an array of environments, each with a `context` name and its own service list. Structured for adding more than dev/prod later. (`overwatch` is dev-only; its namespace is dev-specific.)
- `Service` gains an optional `context` field; when set, the forward is pinned via `--context`. Empty = current context, so the default path is untouched.
- Manager `multiEnv` mode: flattens environments into env-qualified services (`<svc>-<env>`), **disables the ambient-context-change restart** (forwards are pinned, so switching your context shouldn't tear them down), and marks services strict-port.
- Shared `BuildKubectlPortForwardArgs` (unix+windows) so the safety-critical context pinning has a single, tested definition.

## Tests

`go test ./...` green. New tests cover: embedded multi-env load (dev 50xxx / prod 70xxx, distinct contexts), flatten (env-qualified keys, context-pinned, per-env ports, disabled-skipped), `--context` arg construction (with/without), and strict-port loud-fail vs default reassign.

## Try it

```bash
kportforward --multi-env      # dev on 50xxx + prod on 70xxx, simultaneously
kportforward                  # unchanged: single env, current context
```

Note: each environment's forwards authenticate against its own cluster, so the two contexts must each have working credentials (e.g. their kubeconfig users resolve the right AWS profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)