### PR TITLE
Restore overwatch dev port to 50030 (regressed in v1.6.1)

### DIFF
--- a/internal/config/environments.yaml
+++ b/internal/config/environments.yaml
@@ -154,7 +154,7 @@ environments:
     overwatch:
       target: service/overwatch-web
       targetPort: 80
-      localPort: 3030
+      localPort: 50030
       namespace: overwatch-dev-us-a
       type: web
 - name: prod


### PR DESCRIPTION
v1.6.0 (#47) moved overwatch's dev port to `50030` so every dev port sits in the `50xxx` band. The v1.6.1 prod-band fix (#49) regenerated `environments.yaml` from `default.yaml`, which silently reverted overwatch to `3030`. This restores `50030`.

overwatch stays dev-only (dev-specific namespace, no prod entry). One-line config change; `go test ./...` green.